### PR TITLE
Feature: add type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,3 @@
-export declare async function endpoint(): string;
+export = GetIp
+
+declare function GetIp(endpoint?: string) : Promise<string>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export declare async function endpoint(): string;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "Get public IP address in React Native",
   "main": "index.js",
+  "types": "index.d.ts",
   "keywords": [
     "ip",
     "ipv4",


### PR DESCRIPTION
I created this definition file so that Typescript wouldn't get mad at me in another project, and thought I'd share it.

While creating it, I learned that Typescript doesn't have a way to declare that a function might throw an error. That's pretty weird, but it shouldn't cause any issues.